### PR TITLE
Make usable on IronPython under Windows

### DIFF
--- a/pprofile.py
+++ b/pprofile.py
@@ -254,7 +254,9 @@ class ProfileBase(object):
         if relative_path:
             convertPath = _relpath
         else:
-            convertPath = lambda x: x
+            #  qCacheGrind (windows build) uses UNIX path separators instead of Windows.
+            #  Adapt here even if this is probably more of a qCacheGrind issue...
+            convertPath = lambda x: x.replace("\\","/")
         for name in self._getFileNameList(filename):
             printable_name = convertPath(name)
             print >> out, 'fl=%s' % printable_name

--- a/pprofile.py
+++ b/pprofile.py
@@ -175,7 +175,11 @@ class ProfileBase(object):
         # results with f_code.co_filename (ex: easy_install with zipped egg),
         # so inspect current frame instead.
         # XXX: assumes all of pprofile code resides in a single file.
-        result.discard(inspect.currentframe().f_code.co_filename)
+        # Get current file from one of its methods. Compatible with implemantations
+        # that do not have the inspect.currentframe() method (e.g. IronPython)
+        # XXX: still assumes that all of pprofile code is in a single file.
+        # XXX: also assumes that _initStack exists in pprofile module.
+        result.discard(inspect.getsourcefile(_initStack))
         return result
 
     def _getFileNameList(self, filename):

--- a/pprofile.py
+++ b/pprofile.py
@@ -257,7 +257,7 @@ class ProfileBase(object):
         if os.path.sep != "/":
             #  qCacheGrind (windows build) needs at least one UNIX separator in path to find the file.
             #  Adapt here even if this is probably more of a qCacheGrind issue...
-            convertPath = lambda x, cascade=convertPath: cascade('/'.join(os.path.split(x)))
+            convertPath = lambda x, cascade=convertPath: cascade('/'.join(x.split(os.path.sep)))
         for name in self._getFileNameList(filename):
             printable_name = convertPath(name)
             print >> out, 'fl=%s' % printable_name

--- a/pprofile.py
+++ b/pprofile.py
@@ -174,11 +174,10 @@ class ProfileBase(object):
         # Ignore profiling code. __file__ does not always provide consistent
         # results with f_code.co_filename (ex: easy_install with zipped egg),
         # so inspect current frame instead.
-        # XXX: assumes all of pprofile code resides in a single file.
-        # Get current file from one of its methods. Compatible with implemantations
+        # Get current file from one of pprofile methods. Compatible with implemantations
         # that do not have the inspect.currentframe() method (e.g. IronPython)
-        # XXX: still assumes that all of pprofile code is in a single file.
-        # XXX: also assumes that _initStack exists in pprofile module.
+        # XXX: Assumes that all of pprofile code is in a single file.
+        # XXX: Assumes that _initStack exists in pprofile module.
         result.discard(inspect.getsourcefile(_initStack))
         return result
 

--- a/pprofile.py
+++ b/pprofile.py
@@ -253,9 +253,11 @@ class ProfileBase(object):
         if relative_path:
             convertPath = _relpath
         else:
-            #  qCacheGrind (windows build) uses UNIX path separators instead of Windows.
+            convertPath = lambda x: x
+        if os.path.sep != "/":
+            #  qCacheGrind (windows build) needs at least one UNIX separator in path to find the file.
             #  Adapt here even if this is probably more of a qCacheGrind issue...
-            convertPath = lambda x: x.replace("\\","/")
+            convertPath = lambda x, cascade=convertPath: cascade('/'.join(os.path.split(x)))
         for name in self._getFileNameList(filename):
             printable_name = convertPath(name)
             print >> out, 'fl=%s' % printable_name


### PR DESCRIPTION
Hi Vincent,

Here are 2 independent commits that should get your profiler working on a wider range of cases (specifically IronPython on Windows).

First one (@91f9238) removes the need for the inspect.currentframe() method that is not implemented in IronPython.
Second one (@bc1c4df) uses forward slashes as path separators everywhere in order to be compatible with the qCacheGrind windows build from http://sourceforge.net/projects/qcachegrindwin/.

Sorry to dig up old code, but since we have made valuable use of your tools after those small changes I thought I should let others profit. We (have to) use IronPython on windows to write Python plugins for the 3D-modeling software Rhino3D. pprofile was the only detailed and GUI-compatible profiler we found for IronPython that (almost) working.

Best,
Pierre