### PR TITLE
Making changes to support Python 3

### DIFF
--- a/pprofile.py
+++ b/pprofile.py
@@ -452,10 +452,6 @@ class ProfileBase(object):
                     time_per_hit = duration / hits
                 else:
                     time_per_hit = 0
-                try:
-                    line = line.encode('utf-8')
-                except UnicodeDecodeError:
-                    pass
                 print(_ANNOTATE_FORMAT % {
                     'lineno': lineno,
                     'hits': hits,
@@ -504,8 +500,12 @@ class ProfileBase(object):
         """
         Similar to profile.Profile.dump_stats - but different output format !
         """
-        with open(filename, 'w') as out:
-            self.annotate(out)
+        try:
+            with open(filename, 'w', encoding="utf-8") as out:
+                self.annotate(out)
+        except TypeError:
+            with open(filename, 'w') as out:
+                self.annotate(out)
 
     def print_stats(self):
         """

--- a/pprofile.py
+++ b/pprofile.py
@@ -452,14 +452,24 @@ class ProfileBase(object):
                     time_per_hit = duration / hits
                 else:
                     time_per_hit = 0
-                print(_ANNOTATE_FORMAT % {
-                    'lineno': lineno,
-                    'hits': hits,
-                    'time': duration,
-                    'time_per_hit': time_per_hit,
-                    'percent': percent(duration, total_time),
-                    'line': line.rstrip(),
-                }, file=out)
+                try:
+                    print(_ANNOTATE_FORMAT % {
+                        'lineno': lineno,
+                        'hits': hits,
+                        'time': duration,
+                        'time_per_hit': time_per_hit,
+                        'percent': percent(duration, total_time),
+                        'line': line.rstrip(),
+                        }, file=out)
+                except UnicodeEncodeError:
+                    print(_ANNOTATE_FORMAT % {
+                        'lineno': lineno,
+                        'hits': hits,
+                        'time': duration,
+                        'time_per_hit': time_per_hit,
+                        'percent': percent(duration, total_time),
+                        'line': line.rstrip().encode("utf-8"),
+                        }, file=out)
                 for _, _, hits, duration, callee_file, callee_line, \
                         callee_name in call_list_by_line.get(lineno, ()):
                     print(_ANNOTATE_CALL_FORMAT % {

--- a/pprofile.py
+++ b/pprofile.py
@@ -452,13 +452,17 @@ class ProfileBase(object):
                     time_per_hit = duration / hits
                 else:
                     time_per_hit = 0
+                try:
+                    line = line.encode('utf-8')
+                except UnicodeDecodeError:
+                    pass
                 print(_ANNOTATE_FORMAT % {
                     'lineno': lineno,
                     'hits': hits,
                     'time': duration,
                     'time_per_hit': time_per_hit,
                     'percent': percent(duration, total_time),
-                    'line': line.rstrip().encode("utf-8"),
+                    'line': line.rstrip(),
                 }, file=out)
                 for _, _, hits, duration, callee_file, callee_line, \
                         callee_name in call_list_by_line.get(lineno, ()):

--- a/pprofile.py
+++ b/pprofile.py
@@ -123,27 +123,47 @@ class _FileTiming(object):
 
     def getCallListByLine(self):
         result = defaultdict(list)
-        for (line, name, callee), (code, hit, duration) in \
-                self.call_dict.iteritems():
-            result[line].append((
-                code.co_name, code.co_firstlineno,
-                hit, duration,
-                name, callee.co_firstlineno, callee.co_name,
-            ))
+        try:
+            for (line, name, callee), (code, hit, duration) in \
+                    self.call_dict.iteritems():
+                result[line].append((
+                    code.co_name, code.co_firstlineno,
+                    hit, duration,
+                    name, callee.co_firstlineno, callee.co_name,
+                ))
+        except AttributeError:
+            for (line, name, callee), (code, hit, duration) in \
+                    self.call_dict.items():
+                result[line].append((
+                    code.co_name, code.co_firstlineno,
+                    hit, duration,
+                    name, callee.co_firstlineno, callee.co_name,
+                ))
         return result
 
     def getTotalTime(self):
-        return sum(x[2] for x in self.line_dict.itervalues())
+        try:
+            return sum(x[2] for x in self.line_dict.itervalues())
+        except AttributeError:
+            return sum(x[2] for x in self.line_dict.values())
 
     def getTotalHitCount(self):
-        return sum(x[1] for x in self.line_dict.itervalues())
+        try:
+            return sum(x[1] for x in self.line_dict.itervalues())
+        except AttributeError:
+            return sum(x[1] for x in self.line_dict.values())
 
     def getSortKey(self):
         # total duration first, then total hit count for statistical profiling
         result = [0, 0]
-        for _, hit, duration in self.line_dict.itervalues():
-            result[0] += duration
-            result[1] += hit
+        try:
+            for _, hit, duration in self.line_dict.itervalues():
+                result[0] += duration
+                result[1] += hit
+        except AttributeError:
+            for _, hit, duration in self.line_dict.values():
+                result[0] += duration
+                result[1] += hit
         return result
 
 FileTiming = _FileTiming
@@ -438,7 +458,7 @@ class ProfileBase(object):
                     'time': duration,
                     'time_per_hit': time_per_hit,
                     'percent': percent(duration, total_time),
-                    'line': line.rstrip(),
+                    'line': line.rstrip().encode("utf-8"),
                 }, file=out)
                 for _, _, hits, duration, callee_file, callee_line, \
                         callee_name in call_list_by_line.get(lineno, ()):
@@ -785,9 +805,14 @@ class StatisticalThread(threading.Thread, ProfileRunnerBase):
         stop_event = self._stop_event
         wait = partial(stop_event.wait, self._period)
         while self._can_run:
-            for ident, frame in current_frames().iteritems():
-                if test(ident):
-                    sample(frame)
+            try:
+                for ident, frame in current_frames().iteritems():
+                    if test(ident):
+                        sample(frame)
+            except AttributeError:
+                for ident, frame in current_frames().items():
+                    if test(ident):
+                        sample(frame)
             frame = None
             wait()
         stop_event.clear()


### PR DESCRIPTION
1. iteritems() and itervalues() don't exist in Python 3. Catching an AttributeError and using items() and values() when that Exception is thrown.
2. For dump_stats(), setting file encoding to "utf-8" to avoid a UnicodeEncodeError in Python 3.
3. For print_stats(), adding an exception to encode the data to bytes before writing to stdout, to avoid a UnicodeEncodeError in Python 3.