### PR TITLE
Do not apply active `__future__` imports to profiled code

### DIFF
--- a/pprofile.py
+++ b/pprofile.py
@@ -533,7 +533,7 @@ class ProfileRunnerBase(object):
             return func(*args, **kw)
 
     def runfile(self, fd, argv, fd_name='<unknown>', compile_flags=0,
-            dont_inherit=0):
+            dont_inherit=1):
         with fd:
             code = compile(fd.read(), fd_name, 'exec', flags=compile_flags,
                 dont_inherit=dont_inherit)
@@ -868,7 +868,7 @@ def runctx(cmd, globals, locals, filename=None, threads=True, verbose=False):
     """Similar to profile.runctx ."""
     _run(threads, verbose, 'runctx', filename, cmd, globals, locals)
 
-def runfile(fd, argv, fd_name='<unknown>', compile_flags=0, dont_inherit=0,
+def runfile(fd, argv, fd_name='<unknown>', compile_flags=0, dont_inherit=1,
         filename=None, threads=True, verbose=False):
     """
     Run code from given file descriptor with profiling enabled.


### PR DESCRIPTION
Having `dont_inherit=0` as default in the call to `compile()` causes the compiled code to be parsed with `from __future__ import print_function` active, since this is used in `pprofile.py`. This results in  syntax errors if the profiled script uses old non-function `print` statements:

```console
$ cat tst.py
print "Hello world"
$ pprofile tst.py
Command line: ['tst.py']
Total duration: 0s
Traceback (most recent call last):
  File "/home/stephan/.local/bin/pprofile", line 9, in <module>
    load_entry_point('pprofile==1.9', 'console_scripts', 'pprofile')()
  File "/home/stephan/.local/lib/python2.7/site-packages/pprofile.py", line 974, in main
    runner.runpath(options.script, args)
  File "/home/stephan/.local/lib/python2.7/site-packages/pprofile.py", line 555, in runpath
    return self.runfile(open(path, 'rb'), argv, fd_name=path)
  File "/home/stephan/.local/lib/python2.7/site-packages/pprofile.py", line 539, in runfile
    dont_inherit=dont_inherit)
  File "tst.py", line 2
    print "Hello world"
                      ^
SyntaxError: invalid syntax
```

Applying the `__future__` imports from `pprofile.py` to the profiled code doesn't seem useful. Having `dont_inherit=1`, avoiding that issue, seems to be the better default. With this change the above test script can be profiled without errors.