### PR TITLE
New method to get profiler data as python object

### DIFF
--- a/pprofile.py
+++ b/pprofile.py
@@ -375,7 +375,14 @@ class ProfileBase(object):
         print('events: hits us usphit', file=out)
         file_dict = self.file_dict
 
-        convertPath = _qCacheGringAdapt(_path_resolver(relative_path))
+        convertPath = _path_resolver(relative_path)
+        if os.path.sep != "/":
+            # qCacheGrind (windows build) needs at least one UNIX separator
+            # in path to find the file. Adapt here even if this is probably
+            # more of a qCacheGrind issue...
+            convertPath = lambda path, cascade=convertPath: cascade(
+                '/'.join(path.split(os.path.sep))
+            )
 
         for name in self._getFileNameList(filename, may_sort=False):
             printable_name = convertPath(name)
@@ -427,7 +434,7 @@ class ProfileBase(object):
         """
 
         file_dict = self.file_dict
-        convertPath = _qCacheGringAdapt(_path_resolver(relative_path))
+        convertPath = _path_resolver(relative_path)
 
         total_time = self.total_time
         command_profile = {
@@ -961,20 +968,6 @@ def runpath(path, argv, filename=None, threads=True, verbose=False):
     Run code from open-accessible file path with profiling enabled.
     """
     _run(threads, verbose, 'runpath', filename, path, argv)
-
-def _qCacheGringAdapt(path):
-    '''
-    qCacheGrind (windows build) needs at least one UNIX separator
-    in path to find the file. Adapt here even if this is probably
-    more of a qCacheGrind issue...
-    '''
-
-    if os.path.sep != "/":
-        path = lambda x, cascade=path: cascade(
-            '/'.join(x.split(os.path.sep))
-        )
-
-    return path
 
 def _path_resolver(relative_path=True):
     '''

--- a/pprofile.py
+++ b/pprofile.py
@@ -970,10 +970,11 @@ def runpath(path, argv, filename=None, threads=True, verbose=False):
     _run(threads, verbose, 'runpath', filename, path, argv)
 
 _allsep = os.sep + (os.altsep or '')
-def _path_resolver(relative_path=True):
+def _path_resolver(relative_path):
     '''
-    Returns a function that manipulates a path string to be relative if
-    `relative_path' is true, otherwise it returns the identity function.
+    Returns a function that manipulates a path string to be relative (strip
+    absolute components from path) *if* `relative_path' is truthy, otherwise it
+    returns the identity function.
 
     Inspired from zipfile.write().
     '''

--- a/pprofile.py
+++ b/pprofile.py
@@ -380,8 +380,8 @@ class ProfileBase(object):
             # qCacheGrind (windows build) needs at least one UNIX separator
             # in path to find the file. Adapt here even if this is probably
             # more of a qCacheGrind issue...
-            convertPath = lambda path, cascade=convertPath: cascade(
-                '/'.join(path.split(os.path.sep))
+            convertPath = lambda x, cascade=convertPath: cascade(
+                '/'.join(x.split(os.path.sep))
             )
 
         for name in self._getFileNameList(filename, may_sort=False):
@@ -969,6 +969,7 @@ def runpath(path, argv, filename=None, threads=True, verbose=False):
     """
     _run(threads, verbose, 'runpath', filename, path, argv)
 
+_allsep = os.sep + (os.altsep or '')
 def _path_resolver(relative_path=True):
     '''
     Returns a function that manipulates a path string to be relative if
@@ -977,13 +978,12 @@ def _path_resolver(relative_path=True):
     Inspired from zipfile.write().
     '''
 
-    allsep = os.sep + (os.altsep or '')
     relpath_fn = lambda name: name
 
     if relative_path:
         relpath_fn = lambda name: os.path.normpath(
             os.path.splitdrive(name)[1]
-        ).lstrip(allsep)
+        ).lstrip(_allsep)
 
     return relpath_fn
 
@@ -1070,10 +1070,10 @@ def main():
     finally:
         if options.out == '-':
             out = _reopen(sys.stdout, errors='replace')
-            close_fn = lambda: None
+            close = lambda: None
         else:
             out = _open(options.out, 'w', errors='replace')
-            close_fn = out.close
+            close = out.close
         if options.exclude:
             exclusion_search_list = [
                 re.compile(x).search for x in options.exclude
@@ -1096,7 +1096,7 @@ def main():
             commandline=repr(args),
             relative_path=relative_path,
         )
-        close_fn()
+        close()
         zip_path = options.zipfile
         if zip_path:
             convertPath = _path_resolver(relative_path)


### PR DESCRIPTION
Hey!

I needed a way to access the profiler data programmatically; to do this I've implemented the `get_stats` method, and any other changes there are to reduce code-duplication.

The next steps I'd like to work on would be:
1. Rework `annotate' to use`get_stats`
2. Add any missing `callgrind' data to the object returned by`get_stats`, and rework`callgrind`method to also use`get_stats`

To see how this new method is used, please check out the `pydata' branch.  In iPython, you can basically perform things like`ls`,`cat`, and`grep`the files that the profiler picked up, there's a lot of room for awesome features, but I've only been working on what I need most.  Here's a quick demo using a sample file called`sample.py`:

``` python
import time
import os
import pdb

def _sleep(t):
    time.sleep(t / 1000000.0)
    return t

def aaa(a):
    return a

def bbb(b):
    return _sleep(b)

def ccc(c):
    if not os.path.exists('/proc/%d' % c): c ^= c
    return c

print('test')

def foo(a, b, c):
    r = 0

    for i in range(a):
        for j in range(b):
            for k in range(c):
                r += sum([
                    aaa(a), bbb(b),
                    ccc(c)
                ])

    return r

def bar(i=3):
    return foo(i, 20, 100)
```

And now, the profiler:

```
In [31]: import sample
In [33]: fn = (sample.bar, 8)
In [34]: s = pprofiler.Profiler.profile('test@alpha', *fn) # profile sample.bar(8)
In [35]: p = pprofiler.Profiler(s)

# Utility function for color-printing python objects as JSON
In [39]: from pprofile.pprofiler import jprint
In [40]: jprint(p.overhead())
{
  "actual": 18.111714124679565,
  "overhead": 0.0001728534698486328,
  "total": 18.111886978149414
}

# List files, ordered by cumulative time, optionally takes an argument of the number of seconds to match or exceed (reduce output towards the worst-case files) 
In [41]: p.ls()
  0 |   17.3 | /tmp/sample.py
  1 |    0.8 | /opt/lib/python2.7/genericpath.py
  2 |    0.0 | /tmp/pprofile/pprofiler.py

# Catenate the file (using it's path, or index according to p.ls, show time/hit score and line numbers.
In [42]: p.cat(0)
  0.0/0         | 0001 | import time
  0.0/0         | 0002 | import os
  0.0/0         | 0003 | import pdb
  0.0/0         | 0004 |
  0.1/16000     | 0005 | def _sleep(t):
 14.2/16000     | 0006 |     time.sleep(t / 1000000.0)
  0.2/16000     | 0007 |     return t
  0.0/0         | 0008 |
  0.1/16000     | 0009 | def aaa(a):
  0.1/16000     | 0010 |     return a
  0.0/0         | 0011 |
  0.1/16000     | 0012 | def bbb(b):
  0.4/16000     | 0013 |     return _sleep(b)
  0.0/0         | 0014 |
  0.1/16000     | 0015 | def ccc(c):
  0.5/16000     | 0016 |     if not os.path.exists('/proc/%d' % c): c ^= c
  0.2/16000     | 0017 |     return c
  0.0/0         | 0018 |
  0.0/0         | 0019 | print('test')
  0.0/0         | 0020 |
  0.0/1         | 0021 | def foo(a, b, c):
  0.0/1         | 0022 |     r = 0
  0.0/0         | 0023 |
  0.0/9         | 0024 |     for i in range(a):
  0.0/168       | 0025 |         for j in range(b):
  0.2/16160     | 0026 |             for k in range(c):
  0.1/16000     | 0027 |                 r += sum([
  0.6/16000     | 0028 |                     aaa(a), bbb(b),
  0.4/16000     | 0029 |                     ccc(c)
  0.0/0         | 0030 |                 ])
  0.0/0         | 0031 |
  0.0/1         | 0032 |     return r
  0.0/0         | 0033 |
  0.0/1         | 0034 | def bar(i=3):
  0.0/1         | 0035 |     return foo(i, 20, 100)

# Grep for a string in all files known to the profiler
In [43]: p.grep('def ccc')
# file[0]: /tmp/sample.py
  0.1/16000     | 0015 | def ccc(c):

# Get a list of the worst lines of code, exceeding 0.5s here, and optionally limit the search by providing a filter expression (not demonstrated here)
In [54]: jprint(p.get_filtered_profile(0.5))
[
  {
    "address": "/tmp/sample.py:6",
    "datum": {
      "duration": 17.271899461746216,
      "file_name": "/tmp/sample.py",
      "line": {
        "block_id": [
          "/tmp/sample.py",
          "_sleep",
          5
        ],
        "duration": 14.248581409454346,
        "hits": 16000,
        "line": "    time.sleep(t / 1000000.0)",
        "line_no": 6,
        "line_profile": []
      }
    }
  },
  {
    "address": "/tmp/sample.py:28",
    "datum": {
      "duration": 17.271899461746216,
      "file_name": "/tmp/sample.py",
      "line": {
        "block_id": [
          "/tmp/sample.py",
          "foo",
          21
        ],
        "duration": 0.6394095420837402,
        "hits": 16000,
        "line": "                    aaa(a), bbb(b),",
        "line_no": 28,
        "line_profile": [
          {
            "callee_file": "/tmp/sample.py",
            "callee_line": 12,
            "callee_name": "bbb",
            "duration": 15.001068115234375,
            "hits": 16000
          },
          {
            "callee_file": "/tmp/sample.py",
            "callee_line": 9,
            "callee_name": "aaa",
            "duration": 0.20499634742736816,
            "hits": 16000
          }
        ]
      }
    }
  }
]
```
