### PR TITLE
Package license

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
+include COPYING
 include README.rst


### PR DESCRIPTION
Add the license file, `COPYING`, to `MANIFEST.in` so as to include it in `sdist`s and related packages.