### PR TITLE
Add Power Support ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,21 @@
 os: linux
 language: python
+arch:
+  - amd64
+  - ppc64le
 python:
   - "2.7"
   - "3.6"
   - "3.8"
   - "pypy"
   - "pypy3"
+# Disable version pypy, pypy3 for power support
+jobs:
+  exclude:
+   - arch: ppc64le
+     python: "pypy"
+   - arch: ppc64le
+     python: "pypy3"
 install:
   pip install .
 script:


### PR DESCRIPTION
Added power support for the travis.yml file with ppc64le. This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing. I have excluded pypy versions as it is not supported for power. Thanks.